### PR TITLE
Fix Log output for build on multiple workspaces

### DIFF
--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -375,7 +375,7 @@ class NodeIndexCommandController extends CommandController
         $output = '';
         if ($workspace === null) {
             foreach ($this->workspaceRepository->findAll() as $iteratedWorkspace) {
-                $output .= $this->executeInternalCommand('buildWorkspaceInternal', $buildWorkspaceCommandOptions($iteratedWorkspace, $dimensionsValues, $limit, $postfix));
+                $output .= $this->executeInternalCommand('buildWorkspaceInternal', $buildWorkspaceCommandOptions($iteratedWorkspace, $dimensionsValues, $limit, $postfix)) . PHP_EOL;
             }
         } else {
             $output = $this->executeInternalCommand('buildWorkspaceInternal', $buildWorkspaceCommandOptions($workspace, $dimensionsValues, $limit, $postfix));


### PR DESCRIPTION
This fixes the current output being difficult to read due to the string concenation when indexing multiple workspaces and dimensions